### PR TITLE
Release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.0.1] - 2025-01-12
+
+- Consider timezone for semver_datetime tag [#20](https://github.com/yuya-takeyama/monotonix/pull/20)
+- Allow null config [#19](https://github.com/yuya-takeyama/monotonix/pull/19)
+- Update some packages
+
 ## [0.0.0] - 2025-01-06
 
 - Initial release


### PR DESCRIPTION
## [0.0.1] - 2025-01-12

- Consider timezone for semver_datetime tag [#20](https://github.com/yuya-takeyama/monotonix/pull/20)
- Allow null config [#19](https://github.com/yuya-takeyama/monotonix/pull/19)
- Update some packages