### PR TITLE
feat: add /open-release-pr slash command for Claude Code

### DIFF
--- a/.claude/commands/open-release-pr.md
+++ b/.claude/commands/open-release-pr.md
@@ -11,6 +11,13 @@ allowed-tools:
 description: Create release branch, update CHANGELOG, and open a pull request
 ---
 
+## Command Usage
+
+This command expects a semantic version number as the argument.
+
+**Format**: `/open-release-pr <MAJOR.MINOR.PATCH>`
+**Example**: `/open-release-pr 1.2.3` or `/open-release-pr 2.0.0-beta.1`
+
 ## Context
 
 - Script output: !`./scripts/prepare-release-branch.sh $ARGUMENTS`

--- a/.claude/commands/open-release-pr.md
+++ b/.claude/commands/open-release-pr.md
@@ -1,0 +1,57 @@
+---
+allowed-tools:
+  - Bash(git fetch origin main:*)
+  - Bash(git checkout main:*)
+  - Bash(git pull origin main:*)
+  - Bash(git checkout -B release/v$ARGUMENTS:*)
+  - Bash(git status:*)
+  - Bash(git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD:*)
+  - Bash(gh pr create:*)
+  - Read
+  - Edit
+  - MultiEdit
+description: Create release branch, update CHANGELOG, and open a pull request
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Git status: !`git status -s`
+- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
+- Changes since last tag:
+  !`git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD`
+
+## Your task
+
+Create a release PR for version $ARGUMENTS with these steps:
+
+1. **Fetch and checkout latest main**
+   - `git fetch origin main`
+   - `git checkout main`
+   - `git pull origin main`
+
+2. **Create release branch**
+   - `git checkout -B release/v$ARGUMENTS`
+
+3. **Update CHANGELOG.md**
+   - Read the current CHANGELOG.md file
+   - Add a new section `## [v$ARGUMENTS] - YYYY-MM-DD` at the top (after the main heading)
+   - Organize the commits since the last tag into appropriate sections following Keep a Changelog format:
+     - Added
+     - Changed
+     - Fixed
+     - Removed
+   - Use the commit messages to categorize changes appropriately
+   - Preserve the existing changelog format and style
+
+4. **Commit changes**
+   - `git add CHANGELOG.md`
+   - `git commit -m "chore: prepare release v$ARGUMENTS"`
+
+5. **Push branch and create PR**
+   - `git push -u origin release/v$ARGUMENTS`
+   - Create PR using: `gh pr create --title "Release v$ARGUMENTS" --body "## Release v$ARGUMENTS\n\nThis PR prepares the release for version $ARGUMENTS.\n\n### Checklist\n- [ ] CHANGELOG.md updated\n- [ ] Version bumped (if applicable)\n- [ ] All tests passing\n\n🤖 Generated with Claude Code" --draft`
+
+6. **Output**
+   - Show the PR URL
+   - Remind to review the CHANGELOG and merge when ready

--- a/.claude/commands/open-release-pr.md
+++ b/.claude/commands/open-release-pr.md
@@ -1,11 +1,9 @@
 ---
 allowed-tools:
-  - Bash(git fetch origin main:*)
-  - Bash(git checkout main:*)
-  - Bash(git pull origin main:*)
-  - Bash(git checkout -B release/v$ARGUMENTS:*)
-  - Bash(git status:*)
-  - Bash(git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD:*)
+  - Bash(./scripts/prepare-release-branch.sh:*)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(git push:*)
   - Bash(gh pr create:*)
   - Read
   - Edit
@@ -15,28 +13,22 @@ description: Create release branch, update CHANGELOG, and open a pull request
 
 ## Context
 
-- Current branch: !`git branch --show-current`
-- Git status: !`git status -s`
-- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "No tags found"`
-- Changes since last tag:
-  !`git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD`
+- Script output: !`./scripts/prepare-release-branch.sh $ARGUMENTS`
 
 ## Your task
 
 Create a release PR for version $ARGUMENTS with these steps:
 
-1. **Fetch and checkout latest main**
-   - `git fetch origin main`
-   - `git checkout main`
-   - `git pull origin main`
+1. **Prepare release branch**
+   - The script has already:
+     - Fetched and checked out latest main
+     - Created release/v$ARGUMENTS branch
+     - Shown commits since last tag
 
-2. **Create release branch**
-   - `git checkout -B release/v$ARGUMENTS`
-
-3. **Update CHANGELOG.md**
+2. **Update CHANGELOG.md**
    - Read the current CHANGELOG.md file
    - Add a new section `## [v$ARGUMENTS] - YYYY-MM-DD` at the top (after the main heading)
-   - Organize the commits since the last tag into appropriate sections following Keep a Changelog format:
+   - Organize the commits shown by the script into appropriate sections following Keep a Changelog format:
      - Added
      - Changed
      - Fixed
@@ -44,14 +36,14 @@ Create a release PR for version $ARGUMENTS with these steps:
    - Use the commit messages to categorize changes appropriately
    - Preserve the existing changelog format and style
 
-4. **Commit changes**
+3. **Commit changes**
    - `git add CHANGELOG.md`
    - `git commit -m "chore: prepare release v$ARGUMENTS"`
 
-5. **Push branch and create PR**
+4. **Push branch and create PR**
    - `git push -u origin release/v$ARGUMENTS`
    - Create PR using: `gh pr create --title "Release v$ARGUMENTS" --body "## Release v$ARGUMENTS\n\nThis PR prepares the release for version $ARGUMENTS.\n\n### Checklist\n- [ ] CHANGELOG.md updated\n- [ ] Version bumped (if applicable)\n- [ ] All tests passing\n\n🤖 Generated with Claude Code" --draft`
 
-6. **Output**
+5. **Output**
    - Show the PR URL
    - Remind to review the CHANGELOG and merge when ready

--- a/scripts/prepare-release-branch.sh
+++ b/scripts/prepare-release-branch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/prepare-release-branch.sh <version>
+# Example: ./scripts/prepare-release-branch.sh 1.0.0
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: Version number required"
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+RELEASE_BRANCH="release/v${VERSION}"
+
+echo "=== Preparing release v${VERSION} ==="
+
+# Install dependencies and run build/test
+echo "→ Installing dependencies..."
+npm install
+
+echo "→ Building project..."
+npm run build
+
+echo "→ Running tests..."
+npm run test
+
+# Fetch latest main
+echo "→ Fetching latest main branch..."
+git fetch origin main
+
+# Checkout and update main
+echo "→ Checking out main branch..."
+git checkout main
+git pull origin main
+
+# Create release branch
+echo "→ Creating release branch: ${RELEASE_BRANCH}"
+git checkout -B "${RELEASE_BRANCH}"
+
+# Get latest tag
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -z "$LATEST_TAG" ]]; then
+    echo "→ No previous tags found, using first commit"
+    COMMIT_RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
+else
+    echo "→ Latest tag: ${LATEST_TAG}"
+    COMMIT_RANGE="${LATEST_TAG}..HEAD"
+fi
+
+# Output commit history for changelog generation
+echo ""
+echo "=== Commits since ${LATEST_TAG:-beginning} ==="
+git log --oneline ${COMMIT_RANGE}
+
+echo ""
+echo "=== Release branch ready ==="
+echo "Branch: ${RELEASE_BRANCH}"
+echo "Version: v${VERSION}"
+echo "Commit range: ${COMMIT_RANGE}"

--- a/scripts/prepare-release-branch.sh
+++ b/scripts/prepare-release-branch.sh
@@ -6,15 +6,33 @@ set -euo pipefail
 
 VERSION="${1:-}"
 
+# Validate version argument
 if [[ -z "$VERSION" ]]; then
     echo "Error: Version number required"
     echo "Usage: $0 <version>"
+    echo "Example: $0 1.2.3"
+    exit 1
+fi
+
+# Validate version format (semantic versioning)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
+    echo "Error: Invalid version format"
+    echo "Expected format: MAJOR.MINOR.PATCH (e.g., 1.2.3, 2.0.0-beta.1)"
+    echo "Got: $VERSION"
     exit 1
 fi
 
 RELEASE_BRANCH="release/v${VERSION}"
 
 echo "=== Preparing release v${VERSION} ==="
+
+# Check if we have uncommitted changes
+if ! git diff --quiet || ! git diff --staged --quiet; then
+    echo "Error: You have uncommitted changes"
+    echo "Please commit or stash your changes before creating a release"
+    git status --short
+    exit 1
+fi
 
 # Install dependencies and run build/test
 echo "→ Installing dependencies..."


### PR DESCRIPTION
## Summary

- Added  slash command for automating release PR creation
- Created reusable bash script for deterministic git operations
- Implemented strict validation for semantic versioning

## Changes

- **New slash command**: 
  - Accepts semantic version as argument (e.g., )
  - Automates CHANGELOG.md generation using commit history
  - Creates draft PR with release checklist

- **Release preparation script**: Error: Version number required
Usage: scripts/prepare-release-branch.sh <version>
Example: scripts/prepare-release-branch.sh 1.2.3
  - Validates semantic version format
  - Checks for uncommitted changes
  - Runs npm install, build, and test
  - Creates release branch from latest main
  - Shows commit history for CHANGELOG generation

## Benefits

- Reduces manual work for release creation
- Ensures consistent release process
- Separates deterministic operations (bash) from flexible tasks (LLM)
- Prevents common errors with validation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>