### PR TITLE
feat: add shfmt for shell script formatting

### DIFF
--- a/.claude/scripts/format-shfmt.sh
+++ b/.claude/scripts/format-shfmt.sh
@@ -6,10 +6,10 @@ tool_name="$(echo "$json" | jq -r '.tool_name // ""')"
 
 if [[ "$tool_name" =~ ^(Write|Edit|MultiEdit)$ ]]; then
   file="$(echo "$json" | jq -r '.tool_input.file_path // ""')"
-  
+
   if [[ "$file" =~ \.(sh|bash)$ ]] && [[ -f "$file" ]]; then
     cd "$(dirname "$0")/../.."
-    
+
     if command -v shfmt &> /dev/null; then
       echo "Running shfmt on $file" >&2
       shfmt -i 2 -ci -sr -w "$file"

--- a/.claude/scripts/format-shfmt.sh
+++ b/.claude/scripts/format-shfmt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+json="$(cat)"
+tool_name="$(echo "$json" | jq -r '.tool_name // ""')"
+
+if [[ "$tool_name" =~ ^(Write|Edit|MultiEdit)$ ]]; then
+  file="$(echo "$json" | jq -r '.tool_input.file_path // ""')"
+  
+  if [[ "$file" =~ \.(sh|bash)$ ]] && [[ -f "$file" ]]; then
+    cd "$(dirname "$0")/../.."
+    
+    if command -v shfmt &> /dev/null; then
+      echo "Running shfmt on $file" >&2
+      shfmt -i 2 -ci -sr -w "$file"
+    else
+      echo "Warning: shfmt not found, skipping formatting" >&2
+    fi
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": ".claude/scripts/format-prettier.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": ".claude/scripts/format-shfmt.sh",
+            "timeout": 30
           }
         ]
       }

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -31,6 +31,31 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/mvdan/sh/v3.12.0/shfmt_v3.12.0_darwin_amd64",
+      "checksum": "C31548693DE6584E6164B7ED5FBB7B4A083F2D937CA94B4E0DDF59AA461A85E4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mvdan/sh/v3.12.0/shfmt_v3.12.0_darwin_arm64",
+      "checksum": "D903802E0CE3ECBC82B98512F55BA370B0D37A93F3F78DE394F5B657052B33DD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mvdan/sh/v3.12.0/shfmt_v3.12.0_linux_amd64",
+      "checksum": "D9FBB2A9C33D13F47E7618CF362A914D029D02A6DF124064FFF04FD688A745EA",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mvdan/sh/v3.12.0/shfmt_v3.12.0_linux_arm64",
+      "checksum": "5F3FE3FA6A9F766E6A182BA79A94BEF8AFEDAFC57DB0B1AD32B0F67FAE971BA4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mvdan/sh/v3.12.0/shfmt_v3.12.0_windows_amd64.exe",
+      "checksum": "C8BDA517BA1C640CE4A715C0FA665439DDBE4357BA5E9B77B0E51E70E2B9C94B",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_darwin_amd64.tar.gz",
       "checksum": "A8DF4AF42EC777E63E7A3812D8CC7107C037BDAAA225DEF679444F87B5EE1905",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,3 +13,4 @@ registries:
 packages:
   - name: cli/cli@v2.75.0
   - name: suzuki-shunsuke/pinact@v3.3.0
+  - name: mvdan/sh@v3.12.0

--- a/scripts/prepare-release-branch.sh
+++ b/scripts/prepare-release-branch.sh
@@ -8,18 +8,18 @@ VERSION="${1:-}"
 
 # Validate version argument
 if [[ -z "$VERSION" ]]; then
-    echo "Error: Version number required"
-    echo "Usage: $0 <version>"
-    echo "Example: $0 1.2.3"
-    exit 1
+  echo "Error: Version number required"
+  echo "Usage: $0 <version>"
+  echo "Example: $0 1.2.3"
+  exit 1
 fi
 
 # Validate version format (semantic versioning)
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
-    echo "Error: Invalid version format"
-    echo "Expected format: MAJOR.MINOR.PATCH (e.g., 1.2.3, 2.0.0-beta.1)"
-    echo "Got: $VERSION"
-    exit 1
+  echo "Error: Invalid version format"
+  echo "Expected format: MAJOR.MINOR.PATCH (e.g., 1.2.3, 2.0.0-beta.1)"
+  echo "Got: $VERSION"
+  exit 1
 fi
 
 RELEASE_BRANCH="release/v${VERSION}"
@@ -28,10 +28,10 @@ echo "=== Preparing release v${VERSION} ==="
 
 # Check if we have uncommitted changes
 if ! git diff --quiet || ! git diff --staged --quiet; then
-    echo "Error: You have uncommitted changes"
-    echo "Please commit or stash your changes before creating a release"
-    git status --short
-    exit 1
+  echo "Error: You have uncommitted changes"
+  echo "Please commit or stash your changes before creating a release"
+  git status --short
+  exit 1
 fi
 
 # Install dependencies and run build/test
@@ -58,13 +58,13 @@ echo "→ Creating release branch: ${RELEASE_BRANCH}"
 git checkout -B "${RELEASE_BRANCH}"
 
 # Get latest tag
-LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+LATEST_TAG=$(git describe --tags --abbrev=0 2> /dev/null || echo "")
 if [[ -z "$LATEST_TAG" ]]; then
-    echo "→ No previous tags found, using first commit"
-    COMMIT_RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
+  echo "→ No previous tags found, using first commit"
+  COMMIT_RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
 else
-    echo "→ Latest tag: ${LATEST_TAG}"
-    COMMIT_RANGE="${LATEST_TAG}..HEAD"
+  echo "→ Latest tag: ${LATEST_TAG}"
+  COMMIT_RANGE="${LATEST_TAG}..HEAD"
 fi
 
 # Output commit history for changelog generation

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -33,7 +33,7 @@ MAIN_SHA=$(git rev-parse origin/main)
 echo "→ Using commit from origin/main: ${MAIN_SHA:0:7}"
 
 # Check if tag already exists
-if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+if git rev-parse "v${VERSION}" > /dev/null 2>&1; then
   echo "Error: Tag v${VERSION} already exists"
   exit 1
 fi
@@ -42,7 +42,7 @@ fi
 echo "→ Extracting release notes from CHANGELOG.md..."
 
 # Get CHANGELOG.md content from origin/main
-CHANGELOG_CONTENT=$(git show origin/main:CHANGELOG.md 2>/dev/null || echo "")
+CHANGELOG_CONTENT=$(git show origin/main:CHANGELOG.md 2> /dev/null || echo "")
 
 if [[ -z "$CHANGELOG_CONTENT" ]]; then
   echo "Error: CHANGELOG.md not found in origin/main"


### PR DESCRIPTION
## Summary
- Add shfmt v3.12.0 for automatic shell script formatting
- Configure Claude Code hooks to auto-format .sh/.bash files on edit
- Ensure consistent code style across shell scripts with indent=2

## Changes
- Add shfmt to aqua.yaml dependencies
- Create `.claude/scripts/format-shfmt.sh` hook script
- Configure shfmt formatting with:
  - Indent width: 2 spaces (`-i 2`)
  - Case statement indentation (`-ci`)
  - Simplify redundant syntax (`-sr`)
- Update `.claude/settings.json` to include shfmt in PostToolUse hooks
- Format existing shell scripts to match new style

## Test plan
- [x] Install shfmt via aqua
- [x] Test hook execution on shell file edits
- [x] Verify formatting is applied correctly
- [x] Ensure Claude Code hooks work after restart

🤖 Generated with [Claude Code](https://claude.ai/code)